### PR TITLE
fix right alt keycode for windows server

### DIFF
--- a/doc/xkb/keycodes/win
+++ b/doc/xkb/keycodes/win
@@ -93,7 +93,7 @@ default xkb_keycodes "win" {
     <LWIN> = 354;
     <LALT> = 0x3f;
     <SPCE> = 0x40;
-    <RALT> = 319;
+    <LVL3> = 319; // Right Alt
     <RWIN> = 0x203;
     <MENU> = 356;
     <RCTL> = 292;


### PR DESCRIPTION
Mod5 modifier required to type accented characters is mapped to LVL3 to which RALT is mapped on keyboards layout that use it